### PR TITLE
다시

### DIFF
--- a/src/pages/courses/CourseDetail.tsx
+++ b/src/pages/courses/CourseDetail.tsx
@@ -55,7 +55,7 @@ const CourseDetail: React.FC = () => {
 
   const fetchCourse = async () => {
     try {
-      const res = await authFetch(`http://localhost:8080/course/${id}`);
+      const res = await authFetch(`http://localhost:8080/recommended-course/${id}`);
       if (res.status === 401) {
         setError("로그인이 필요합니다.");
         return;
@@ -82,6 +82,7 @@ const CourseDetail: React.FC = () => {
     } catch (err) {
       console.error("통계 정보 로딩 실패:", err);
     }
+    console.log("✅ stats 상태:", stats);
   };
 
   useEffect(() => {
@@ -159,6 +160,7 @@ const CourseDetail: React.FC = () => {
 
   return (
     <div className={styles.container}>
+      {stats && <CourseStatus stats={stats} courseId={Number(id)} />}
       <h2>🏁 {course.title}</h2>
       <p>📍 도착지: {course.endLocationName}</p>
       <p>📏 거리: {course.totalDistance} km</p>

--- a/src/pages/courses/CourseStatus.tsx
+++ b/src/pages/courses/CourseStatus.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import styles from "./courseStatus.module.css";
 import { formatElapsedTime } from "../../utils/timeUtils";
+import { useEffect } from "react";
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, LabelList } from "recharts";
 
 interface RunnerStat {
@@ -27,14 +28,25 @@ interface CourseStatusProps {
 const CourseStatus = ({ stats, courseId }: CourseStatusProps) => {
   const navigate = useNavigate();
 
+  console.log("🚀 CourseStatus 렌더링됨");
+  console.log("📦 courseId:", courseId);
+  console.log("📊 stats:", stats);
+  alert("✅ CourseStatus 컴포넌트가 실행됨");
+  alert("🧪 CourseStatus 진입했는지 테스트 중");
+
   const paceData = [
     { name: "평균", pace: stats.averagePace },
     { name: "나", pace: stats.myAveragePace ?? 0 },
   ];
 
+  useEffect(() => {
+    console.log("🚀 CourseStatus 렌더링됨");
+    console.log("📊 받은 stats:", stats);
+  }, [stats]);
+
   return (
     <div className={styles.container}>
-      <h2 className={styles.title}>📊 추천 코스 통계</h2>
+      <h2 className={styles.title}>📊 인기 추천코스 통계</h2>
 
       <div className={styles.scrollBox}>
         <p>🔥 총 완주: {stats.totalCompletionCount}명</p>


### PR DESCRIPTION
✨ 작업 내용
추천 코스 상세 페이지에서 /course/{id} → /recommended-course/{id}로 API 경로 수정
통계 API는 /stats/recommended-course/{id} 사용하여 코스별 통계 불러오기 구현
CourseStatus는 통계 데이터가 존재할 경우에만 렌더링되도록 조건부 처리
존재하지 않는 코스 ID 접근 시 에러 메시지 표시 추가
통계가 없는 경우도 정상 대응되도록 처리 (404 대응)