### PR TITLE
추천코스 상세 정보와 통계 정보 통합

### DIFF
--- a/src/pages/courses/CourseDetail.tsx
+++ b/src/pages/courses/CourseDetail.tsx
@@ -9,6 +9,7 @@ import CourseStatus from "./CourseStatus";
 interface CourseDetail {
   id: number;
   userId: number;
+  userName: string;
   title: string;
   description: string;
   totalDistance: number;
@@ -25,6 +26,9 @@ interface RunnerStat {
 }
 
 interface CourseStats {
+  courseId: number;
+  courseTitle: string;
+  creatorName: string;
   courseDistanceKm: number;
   totalCompletionCount: number;
   uniqueRunnerCount: number;
@@ -42,50 +46,41 @@ const CourseDetail: React.FC = () => {
   const { accessToken, user: currentUser, isAuthReady } = useAuth();
   const authFetch = useAuthFetch();
 
-  const [course, setCourse] = useState<CourseDetail | null>(null);
+  const [course, setCourse] = useState<(CourseDetail & CourseStats) | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [stats, setStats] = useState<CourseStats | null>(null);
+  const [statsError, setStatsError] = useState(false);
 
-  const fetchCourse = async () => {
+  const fetchCourseWithStatus = async () => {
     if (!id) return;
 
     try {
       const res = await authFetch(`http://localhost:8080/course/${id}`);
+
       if (res.status === 401) {
-        setError("로그인이 필요합니다.");
+        setError("🔐 로그인이 필요합니다.");
         return;
       }
+
       if (!res.ok) throw new Error("응답 실패");
 
-      const data: CourseDetail = await res.json();
+      const data: CourseDetail & CourseStats = await res.json();
       setCourse(data);
+
+      // 통계 필드가 아예 누락된 경우에만 통계 오류로 간주
+      if (data.totalCompletionCount === undefined || data.topRunners === undefined) {
+        setStatsError(true);
+      } else {
+        setStatsError(false);
+      }
     } catch (err) {
       console.error("코스 정보 로딩 실패:", err);
-      setError("코스 정보를 불러오는 중 오류가 발생했습니다.");
-    }
-  };
-
-  const fetchStats = async () => {
-    if (!id) return;
-
-    try {
-      const res = await authFetch(`http://localhost:8080/course/${id}`);
-      if (!res.ok) {
-        if (res.status === 404) return;
-        throw new Error("통계 요청 실패");
-      }
-      const data: CourseStats = await res.json();
-      setStats(data);
-    } catch (err) {
-      console.error("통계 정보 로딩 실패:", err);
+      setError("❌ 코스 정보를 불러오는 중 오류가 발생했습니다.");
     }
   };
 
   useEffect(() => {
-    console.log("현재 코스 id:", id);
     if (isAuthReady && accessToken && currentUser?.userId && id) {
-      fetchCourse();
-      fetchStats();
+      fetchCourseWithStatus();
     }
   }, [isAuthReady, accessToken, currentUser?.userId, id]);
 
@@ -152,8 +147,9 @@ const CourseDetail: React.FC = () => {
 
   return (
     <div className={styles.container}>
-      {stats && <CourseStatus stats={stats} courseId={Number(id)} />}
+      {course && <CourseStatus stats={course} courseId={course.id} />}
       <h2>🏁 {course.title}</h2>
+      <p>🏃‍♂️ {course.userName}님이 만든 러닝 코스!</p>
       <p>📍 도착지: {course.endLocationName}</p>
       <p>📏 거리: {course.totalDistance} km</p>
       <p>❤️ 좋아요: {course.likeCount}</p>

--- a/src/pages/courses/CourseStatus.tsx
+++ b/src/pages/courses/CourseStatus.tsx
@@ -25,24 +25,11 @@ interface CourseStatusProps {
   courseId: number;
 }
 
-const CourseStatus = ({ stats, courseId }: CourseStatusProps) => {
-  const navigate = useNavigate();
-
-  console.log("🚀 CourseStatus 렌더링됨");
-  console.log("📦 courseId:", courseId);
-  console.log("📊 stats:", stats);
-  alert("✅ CourseStatus 컴포넌트가 실행됨");
-  alert("🧪 CourseStatus 진입했는지 테스트 중");
-
+const CourseStatus = ({ stats }: CourseStatusProps) => {
   const paceData = [
     { name: "평균", pace: stats.averagePace },
     { name: "나", pace: stats.myAveragePace ?? 0 },
   ];
-
-  useEffect(() => {
-    console.log("🚀 CourseStatus 렌더링됨");
-    console.log("📊 받은 stats:", stats);
-  }, [stats]);
 
   return (
     <div className={styles.container}>

--- a/src/pages/courses/PopularCourses.tsx
+++ b/src/pages/courses/PopularCourses.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import styles from "./popularCourses.module.css";
+import { useAuthFetch } from "../../utils/useAuthFetch";
 
 interface PopularCourse {
   courseId: number;
   courseTitle: string;
   creatorName: string;
-  distanceKm: number;
+  totalDistance: number;
   totalCompletionCount: number;
   uniqueRunnerCount: number;
   averagePace: number;
@@ -17,9 +18,10 @@ const PopularCourses = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const navigate = useNavigate();
+  const authFetch = useAuthFetch();
 
   useEffect(() => {
-    fetch("/stats/popular-courses")
+    authFetch("/stats/popular-courses")
       .then((res) => res.json())
       .then(setCourses)
       .catch(() => setError("데이터를 불러오지 못했습니다."))
@@ -34,7 +36,7 @@ const PopularCourses = () => {
       {courses.map((course) => (
         <div key={course.courseId} className={styles.courseCard} onClick={() => navigate(`/course/${course.courseId}`)}>
           <h3>{course.courseTitle}</h3>
-          <p>🏃 {course.distanceKm.toFixed(1)}km</p>
+          <p>🏃 {course.totalDistance.toFixed(1)}km</p>
           <p>🔥 {course.totalCompletionCount}명 완주</p>
           <p>👥 {course.uniqueRunnerCount}명 참여</p>
           <p>⏱️ {course.averagePace.toFixed(1)}분/km</p>

--- a/src/utils/useAuthFetch.ts
+++ b/src/utils/useAuthFetch.ts
@@ -38,6 +38,7 @@ export const useAuthFetch = () => {
   // ✅ 메인 fetch 함수
   const authFetch = async (url: string, options: AuthFetchOptions = {}, retryCount: number = 0): Promise<Response> => {
     console.log("✅ authFetch 실행됨. 현재 accessToken:", accessToken, "| retryCount:", retryCount);
+    console.log("📡 요청 URL:", url);
 
     let token = accessToken;
 


### PR DESCRIPTION
✨ 작업 내용
기존 /course/{id} 요청 시 코스 정보만 받던 구조를 개선

코스 상세 정보 + 통계 정보를 통합하여 한번의 요청으로 처리

CourseDetail.tsx에서 fetchCourse() / fetchStats() 함수 제거하고 fetchCourseWithStatus()로 통합

통계 오류 발생 시 시각적으로 구분되는 fallback 메시지 표시

401 인증 오류, 코스 로딩 실패, 통계 실패 각각의 상태를 구분 처리

CourseStatus 컴포넌트는 기존대로 사용되며, 통합된 course 데이터를 그대로 전달